### PR TITLE
Add missing submodules and data to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.16.0
 scipy>=1.1.0
 torch>=1.1.0
 torchvision>=0.3.0
-opencv-python>= 3.4.2
+opencv-python>=3.4.2

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 import shutil
 from setuptools import find_namespace_packages, setup
@@ -13,6 +14,18 @@ def clean_repo():
     if os.path.isdir(build_folder):
         shutil.rmtree(build_folder, ignore_errors=True)
 
+def pull_first():
+    """This script is in a git directory that can be pulled."""
+    cwd = os.getcwd()
+    gitdir = os.path.dirname(os.path.realpath(__file__))
+    os.chdir(gitdir)
+    try:
+        subprocess.call(['git', 'lfs', 'pull'])
+    except subprocess.CalledProcessError:
+        raise RuntimeError("Make sure git-lfs is installed!")
+    os.chdir(cwd)
+
+pull_first()
 
 # Read version string
 _version = None

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import shutil
-from setuptools import setup
+from setuptools import find_namespace_packages, setup
 
 
 def clean_repo():
@@ -33,7 +33,12 @@ config = {
     'description': 'A collection of pretrained face detectors including S3FD and RetinaFace.',
     'author': 'Jie Shen',
     'author_email': 'js1907@imperial.ac.uk',
-    'packages': ['ibug.face_detection'],
+    'packages': find_namespace_packages(),
+    'package_data': {
+        'ibug.face_detection.s3fd.weights': ['*.pth'],
+        'ibug.face_detection.retina_face.weights': ['*.pth'],
+        'ibug.face_detection.utils.data': ['*.npy'],
+    },
     'install_requires': ['numpy>=1.16.0', 'scipy>=1.1.0', 'torch>=1.1.0',
                          'torchvision>=0.3.0', 'opencv-python>= 3.4.2'],
     'zip_safe': False


### PR DESCRIPTION
Hello!

Thanks for making this package. I want to apply this in my own project and I tried to install this as [a git dependency using Poetry](https://python-poetry.org/docs/dependency-specification/#git-dependencies), because I'd prefer to use Poetry for all my dependency management.

Installation passed, but when I tried to import modules, it failed because submodules were missing. After looking at the setuptools documentation, I modified the `setup.py` configuration for [finding packages](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-namespace-packages) and [data files](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#subdirectory-for-data-files). Additionally, since there are git LFS files in this repo, I added a `git lfs pull` call to the `setup.py` script by adapting the code shown in this [stackoverflow answer](https://stackoverflow.com/a/58932741). The call assumes user has git LFS installed, otherwise it will fail and complain about missing git LFS.

I've tested that the proposed changes work by adding my local copy as [a path dependency](https://python-poetry.org/docs/dependency-specification/#path-dependencies). The package gets installed to a Poetry-managed virtual environment with all the submodules and weight files. And running `RetinaFacePredictor(threshold=0.8, device='cuda:0', model=RetinaFacePredictor.get_model('resnet50'))` loaded the model without problems.

In the third commit I just fixed a small typo in `requirements.txt` while I was at it.

I'll make a similar pull request for the `face_alignment` package.